### PR TITLE
[Backend] As a user, I can filter the report by keyword

### DIFF
--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -46,12 +46,7 @@ func (c *DashboardController) actionPolicyMapping() {
 func (c *DashboardController) Index() {
 	web.ReadFromRequest(&c.Controller)
 
-	var keyword string
-	err := c.Ctx.Input.Bind(&keyword, "keyword")
-	if err != nil {
-		logs.Critical(fmt.Sprintf("Get input keyword failed: %v", err.Error()))
-	}
-
+	keyword := c.GetString("keyword")
 	queryList := map[string]interface{}{
 		"user_id":            c.CurrentUser.Id,
 		"keyword__icontains": keyword,

--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -46,9 +46,17 @@ func (c *DashboardController) actionPolicyMapping() {
 func (c *DashboardController) Index() {
 	web.ReadFromRequest(&c.Controller)
 
-	queryList := map[string]interface{}{
-		"user_id": c.CurrentUser.Id,
+	var keyword string
+	err := c.Ctx.Input.Bind(&keyword, "keyword")
+	if err != nil {
+		logs.Critical(fmt.Sprintf("Get input keyword failed: %v", err.Error()))
 	}
+
+	queryList := map[string]interface{}{
+		"user_id":            c.CurrentUser.Id,
+		"keyword__icontains": keyword,
+	}
+
 	totalRows, err := models.CountAllKeyword(queryList)
 	if err != nil {
 		logs.Critical(fmt.Sprintf("Get total rows failed: %v", err.Error()))
@@ -67,6 +75,7 @@ func (c *DashboardController) Index() {
 		}
 	}
 
+	c.Data["Keyword"] = keyword
 	c.Data["XSRFForm"] = template.HTML(c.XSRFFormHTML())
 	c.Layout = "layouts/application.html"
 	c.TplName = "dashboard/index.html"

--- a/controllers/dashboard_test.go
+++ b/controllers/dashboard_test.go
@@ -165,12 +165,15 @@ var _ = Describe("DashboardController", func() {
 			})
 
 			Context("given `keyword` param is set", func() {
-				It("shows only `keyword` filter records", func() {
-					keywordFilter := "keyword_keyword_keyword"
+				It("shows only `keyword` filtered records", func() {
+					keywordFilter := "expected_keyword"
 					user := FabricateUser(faker.Email(), faker.Password())
+					// Exact match keyword
 					_ = FabricateKeyword(keywordFilter, faker.URL(), 0, user)
+					// Fuzzy match keyword
 					_ = FabricateKeyword(fmt.Sprintf("%v %v %v", faker.Word(), keywordFilter, faker.Word()), faker.URL(), 0, user)
-					_ = FabricateKeyword("paragraph_paragraph_paragraph", faker.URL(), 0, user)
+					// non-match keyword
+					_ = FabricateKeyword("nonexpected__keyword", faker.URL(), 0, user)
 
 					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/dashboard?keyword=%v", keywordFilter), nil, nil, user)
 					body, err := ioutil.ReadAll(response.Body)

--- a/controllers/dashboard_test.go
+++ b/controllers/dashboard_test.go
@@ -163,6 +163,35 @@ var _ = Describe("DashboardController", func() {
 					Expect(len(matches)).To(BeZero())
 				})
 			})
+
+			Context("given `keyword` param is set", func() {
+				It("shows only `keyword` filter records", func() {
+					keywordFilter := "keyword_keyword_keyword"
+					user := FabricateUser(faker.Email(), faker.Password())
+					_ = FabricateKeyword(keywordFilter, faker.URL(), 0, user)
+					_ = FabricateKeyword(fmt.Sprintf("%v %v %v", faker.Word(), keywordFilter, faker.Word()), faker.URL(), 0, user)
+					_ = FabricateKeyword("paragraph_paragraph_paragraph", faker.URL(), 0, user)
+
+					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/dashboard?keyword=%v", keywordFilter), nil, nil, user)
+					body, err := ioutil.ReadAll(response.Body)
+					if err != nil {
+						Fail("Read body content failed: " + err.Error())
+					}
+					err = response.Body.Close()
+					if err != nil {
+						Fail("Close body content failed: " + err.Error())
+					}
+
+					r, err := regexp.Compile(keywordFilter)
+					if err != nil {
+						Fail("Regexp failed: " + err.Error())
+					}
+
+					matches := r.FindAllString(string(body), -1)
+
+					Expect(len(matches)).To(BeNumerically("==", 2))
+				})
+			})
 		})
 
 		Context("when the user has NOT signed in yet", func() {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go-crawler-challenge
 go 1.15
 
 require (
+	github.com/PuerkitoBio/goquery v1.6.1
 	github.com/beego/beego/v2 v2.0.1
 	github.com/bxcodec/faker/v3 v3.6.0
 	github.com/dnaeon/go-vcr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/PuerkitoBio/goquery v1.6.1 h1:FgjbQZKl5HTmcn4sKBgvx8vv63nhyhIpv7lJpFGCWpk=
+github.com/PuerkitoBio/goquery v1.6.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/models/keyword_test.go
+++ b/models/keyword_test.go
@@ -99,6 +99,27 @@ var _ = Describe("Keyword", func() {
 				Expect(keywords[0].Id).To(Equal(keyword.Id))
 			})
 
+			Context("given an operator with case insensitive contain `keyword`", func() {
+				It("returns only `keyword` filter records", func() {
+					containKeyword := "keyword_keyword"
+					var queryList = map[string]interface{}{"keyword__icontains": containKeyword}
+
+					user := FabricateUser(faker.Email(), faker.Password())
+					firstKeyword := FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+					secondKeyword := FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+					thirdKeyword := FabricateKeyword(fmt.Sprintf("%v %v %v", faker.Word(), containKeyword, faker.Word()), faker.URL(), 0, user)
+
+					keywords, err := models.GetAllKeyword(queryList, []string{}, 0, 10)
+					if err != nil {
+						Fail(fmt.Sprintf("Get all keywords failed: %v", err.Error()))
+					}
+
+					Expect(keywords[0].Id).NotTo(Equal(firstKeyword.Id))
+					Expect(keywords[0].Id).NotTo(Equal(secondKeyword.Id))
+					Expect(keywords[0].Id).To(Equal(thirdKeyword.Id))
+				})
+			})
+
 			Context("given order by `id` in ascending order", func() {
 				It("orders the first record to the top of the list", func() {
 					orderBy := []string{"id asc"}

--- a/models/keyword_test.go
+++ b/models/keyword_test.go
@@ -101,13 +101,13 @@ var _ = Describe("Keyword", func() {
 
 			Context("given an operator with case insensitive contain `keyword`", func() {
 				It("returns only `keyword` filter records", func() {
-					containKeyword := "keyword_keyword"
+					containKeyword := "expected_keyword"
 					var queryList = map[string]interface{}{"keyword__icontains": containKeyword}
 
 					user := FabricateUser(faker.Email(), faker.Password())
 					firstKeyword := FabricateKeyword(faker.Word(), faker.URL(), 0, user)
 					secondKeyword := FabricateKeyword(faker.Word(), faker.URL(), 0, user)
-					thirdKeyword := FabricateKeyword(fmt.Sprintf("%v %v %v", faker.Word(), containKeyword, faker.Word()), faker.URL(), 0, user)
+					matchedKeyword := FabricateKeyword(fmt.Sprintf("%v %v %v", faker.Word(), containKeyword, faker.Word()), faker.URL(), 0, user)
 
 					keywords, err := models.GetAllKeyword(queryList, []string{}, 0, 10)
 					if err != nil {
@@ -116,7 +116,8 @@ var _ = Describe("Keyword", func() {
 
 					Expect(keywords[0].Id).NotTo(Equal(firstKeyword.Id))
 					Expect(keywords[0].Id).NotTo(Equal(secondKeyword.Id))
-					Expect(keywords[0].Id).To(Equal(thirdKeyword.Id))
+
+					Expect(keywords[0].Id).To(Equal(matchedKeyword.Id))
 				})
 			})
 


### PR DESCRIPTION
Resolve https://github.com/Lahphim/go-crawler-challenge/issues/65

## What happened 👀

When the user submits the keyword filter, the system will process all the user's report containing with the given keywords.

## Insight 📝

- [x] Retrieve keyword filter from the dashboard
- [x] Filter keyword list following the given keyword
- [x] Update the list of keyword

In BeeGo, they provide some operations with `icontains` (https://beego.me/docs/mvc/model/query.md#icontains)
For this `icontains`, it will be replace with `LIKE` operation.

## Proof Of Work 📹

Demo
![2564-03-23 02 20 44](https://user-images.githubusercontent.com/749672/112046444-9f51a400-8b7e-11eb-952e-c7195ac20a17.gif)

