### PR TITLE
[API] As a user, I can query all the stored data

### DIFF
--- a/controllers/api/base.go
+++ b/controllers/api/base.go
@@ -124,6 +124,8 @@ func (c *BaseController) RenderError(title string, detail string, status int, co
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusInternalServerError)
 	}
+
+	c.StopRun()
 }
 
 func (c *BaseController) handleAuthorizeRequest() {
@@ -134,15 +136,11 @@ func (c *BaseController) handleAuthorizeRequest() {
 		err := c.validateBearerToken()
 		if err != nil {
 			c.RenderUnauthorizedError(err)
-
-			return
 		}
 
 		err = c.validateExistingUser()
 		if err != nil {
 			c.RenderUnauthorizedError(err)
-
-			return
 		}
 	}
 }

--- a/controllers/api/base.go
+++ b/controllers/api/base.go
@@ -29,6 +29,8 @@ type Policy struct {
 }
 
 func (c *BaseController) Prepare() {
+	c.Ctx.Output.Header("Content-Type", ContentType)
+
 	c.disableXSRF()
 	c.initActionPolicy()
 
@@ -88,7 +90,6 @@ func (c *BaseController) RenderJSON(data interface{}, status int) {
 }
 
 func (c *BaseController) renderJSON(payloader interface{}, status int) {
-	c.Ctx.Output.Header("Content-Type", ContentType)
 	c.Ctx.ResponseWriter.WriteHeader(status)
 
 	c.Data["json"] = payloader
@@ -111,7 +112,6 @@ func (c *BaseController) RenderUnauthorizedError(err error) {
 }
 
 func (c *BaseController) RenderError(title string, detail string, status int, code string) {
-	c.Ctx.Output.Header("Content-Type", ContentType)
 	c.Ctx.ResponseWriter.WriteHeader(status)
 
 	writer := c.Ctx.ResponseWriter

--- a/controllers/api/base.go
+++ b/controllers/api/base.go
@@ -54,7 +54,7 @@ func (c *BaseController) MappingPolicy(method string, policy Policy) {
 	c.actionPolicy[method] = policy
 }
 
-func (c *BaseController) RenderJSONMany(data interface{}, meta *jsonapi.Meta, links *jsonapi.Links, status int) {
+func (c *BaseController) RenderJSONList(data interface{}, meta *jsonapi.Meta, links *jsonapi.Links, status int) {
 	response, err := jsonapi.Marshal(data)
 	if err != nil {
 		c.RenderGenericError(err)

--- a/controllers/api/base.go
+++ b/controllers/api/base.go
@@ -40,6 +40,14 @@ func (c *BaseController) Prepare() {
 	c.handleAuthorizeRequest()
 }
 
+func (c *BaseController) GetPageSize() (pageSize int) {
+	return DefaultPageSize
+}
+
+func (c *BaseController) GetOrderBy() (orderBy []string) {
+	return DefaultOrderBy
+}
+
 func (c *BaseController) MappingPolicy(method string, policy Policy) {
 	c.actionPolicy[method] = policy
 }

--- a/controllers/api/constants.go
+++ b/controllers/api/constants.go
@@ -13,6 +13,7 @@ var (
 	DefaultOrderBy = []string{"created_at desc"}
 
 	ErrorInvalidUser           = errors.New("invalid user")
+	ErrorInvalidPayloaderType  = errors.New("invalid payloader type")
 	ErrorMissingAccessToken    = errors.New("missing access token")
 	ErrorNotFoundUser          = errors.New("user not found")
 	ErrorRetrieveKeywordFailed = errors.New("there was a problem retrieving all keywords")

--- a/controllers/api/constants.go
+++ b/controllers/api/constants.go
@@ -4,10 +4,16 @@ import (
 	"errors"
 )
 
-const ContentType = "application/vnd.api+json; charset=utf-8"
+const (
+	ContentType     = "application/vnd.api+json; charset=utf-8"
+	DefaultPageSize = 10
+)
 
 var (
-	ErrorInvalidUser        = errors.New("invalid user")
-	ErrorMissingAccessToken = errors.New("missing access token")
-	ErrorNotFoundUser       = errors.New("user not found")
+	DefaultOrderBy = []string{"created_at desc"}
+
+	ErrorInvalidUser           = errors.New("invalid user")
+	ErrorMissingAccessToken    = errors.New("missing access token")
+	ErrorNotFoundUser          = errors.New("user not found")
+	ErrorRetrieveKeywordFailed = errors.New("there was a problem retrieving all keywords")
 )

--- a/controllers/api/constants.go
+++ b/controllers/api/constants.go
@@ -13,7 +13,7 @@ var (
 	DefaultOrderBy = []string{"created_at desc"}
 
 	ErrorInvalidUser           = errors.New("invalid user")
-	ErrorInvalidPayloaderType  = errors.New("invalid payloader type")
+	ErrorInvalidPayloaderType  = errors.New("invalid payload type")
 	ErrorMissingAccessToken    = errors.New("missing access token")
 	ErrorNotFoundUser          = errors.New("user not found")
 	ErrorRetrieveKeywordFailed = errors.New("there was a problem retrieving all keywords")

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -64,8 +64,6 @@ func (c *KeywordController) Index() {
 	keywords, err := models.GetAllKeyword(queryList, orderByList, int64(paginator.Offset()), int64(pageSize))
 	if err != nil {
 		c.RenderGenericError(ErrorRetrieveKeywordFailed)
-
-		return
 	}
 
 	serializer := v1serializers.KeywordList{
@@ -96,8 +94,6 @@ func (c *KeywordController) TextSearch() {
 	err = textSearchForm.Create()
 	if err != nil {
 		c.RenderGenericError(err)
-
-		return
 	}
 
 	serializer := v1serializers.KeywordScraper{Message: "Scraping a keyword :)"}

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -53,8 +53,6 @@ func (c *KeywordController) Index() {
 	totalRows, err := models.CountAllKeyword(queryList)
 	if err != nil {
 		c.RenderGenericError(ErrorRetrieveKeywordFailed)
-
-		return
 	}
 
 	orderByList := c.GetOrderBy()

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -1,16 +1,15 @@
 package apiv1controllers
 
 import (
-	"go-crawler-challenge/models"
 	"net/http"
-
-	"github.com/beego/beego/v2/adapter/utils/pagination"
 
 	. "go-crawler-challenge/controllers/api"
 	form "go-crawler-challenge/forms/keyword"
+	"go-crawler-challenge/models"
 	v1serializers "go-crawler-challenge/serializers/v1"
 
 	"github.com/beego/beego/v2/adapter/context"
+	"github.com/beego/beego/v2/adapter/utils/pagination"
 )
 
 // KeywordController operations for Keyword
@@ -35,6 +34,15 @@ func (c *KeywordController) actionPolicyMapping() {
 	c.MappingPolicy("TextSearch", Policy{RequireAuthenticatedUser: true})
 }
 
+// Index handles keyword list
+// @Title Index
+// @Description response with keyword list filterable with keyword and page number
+// @Success 200 {object} v1serializers.KeywordList
+// @Param keyword	query string	false
+// @Param p			query integer	false
+// @Failure 500 Internal Server Error
+// @Accept json
+// @router /api/v1/keywords [get]
 func (c *KeywordController) Index() {
 	keyword := c.GetString("keyword")
 	queryList := map[string]interface{}{
@@ -62,11 +70,10 @@ func (c *KeywordController) Index() {
 
 	serializer := v1serializers.KeywordList{
 		KeywordList: keywords,
-		TotalRows:   int(totalRows),
-		PageSize:    pageSize,
+		Paginator:   paginator,
 	}
 
-	c.RenderJSON(serializer.Data(), http.StatusOK)
+	c.RenderJSONMany(serializer.Data(), serializer.Meta(), serializer.Links(), http.StatusOK)
 }
 
 // TextSearch handles keyword for scrapping

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -73,7 +73,7 @@ func (c *KeywordController) Index() {
 		Paginator:   paginator,
 	}
 
-	c.RenderJSONMany(serializer.Data(), serializer.Meta(), serializer.Links(), http.StatusOK)
+	c.RenderJSONList(serializer.Data(), serializer.Meta(), serializer.Links(), http.StatusOK)
 }
 
 // TextSearch handles keyword for scrapping

--- a/controllers/api/v1/keyword_test.go
+++ b/controllers/api/v1/keyword_test.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 
 	"go-crawler-challenge/models"
+	v1serializers "go-crawler-challenge/serializers/v1"
 	. "go-crawler-challenge/tests"
 	. "go-crawler-challenge/tests/custom_matchers"
 	. "go-crawler-challenge/tests/fixtures"
 
 	"github.com/bxcodec/faker/v3"
+	"github.com/google/jsonapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -22,6 +25,119 @@ var _ = Describe("KeywordController", func() {
 		TruncateTable("oauth2_clients")
 		TruncateTable("keyword")
 		TruncateTable("user")
+	})
+
+	Describe("GET /api/v1/keywords", func() {
+		Context("given a valid access token", func() {
+			It("returns status 200", func() {
+				oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+				user := FabricateUser(faker.Email(), faker.Password())
+				_ = FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+				_ = FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+
+				anotherUser := FabricateUser(faker.Email(), faker.Password())
+				_ = FabricateKeyword(faker.Word(), faker.URL(), 0, anotherUser)
+
+				accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+				response := MakeAuthenticatedRequest("GET", "/api/v1/keywords", headers, nil, nil)
+
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("matches with valid schema", func() {
+				oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+				user := FabricateUser(faker.Email(), faker.Password())
+				_ = FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+				_ = FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+
+				anotherUser := FabricateUser(faker.Email(), faker.Password())
+				_ = FabricateKeyword(faker.Word(), faker.URL(), 0, anotherUser)
+
+				accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+				response := MakeAuthenticatedRequest("GET", "/api/v1/keywords", headers, nil, nil)
+
+				Expect(response).To(MatchJSONSchema("keyword/list/valid"))
+			})
+
+			Context("given `p`(page) param is set", func() {
+				It("shows only records in page number 2", func() {
+					pageAt := 2
+					totalRecords := 12
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					for i := 1; i <= totalRecords; i++ {
+						_ = FabricateKeyword(fmt.Sprintf("key%02dword", i), "https://www.sample.com", 0, user)
+					}
+
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/api/v1/keywords?p=%v", pageAt), headers, nil, nil)
+
+					responseKeywords, err := jsonapi.UnmarshalManyPayload(response.Body, reflect.TypeOf(new(v1serializers.KeywordItemResponse)))
+					if err != nil {
+						Fail(fmt.Sprintf("Unmarshal many payload `KeywordItemResponse` list failed: %v", err.Error()))
+					}
+
+					Expect(len(responseKeywords)).To(Equal(2))
+					Expect(responseKeywords[0].(*v1serializers.KeywordItemResponse).Keyword).To(Equal("key02word"))
+					Expect(responseKeywords[1].(*v1serializers.KeywordItemResponse).Keyword).To(Equal("key01word"))
+				})
+			})
+
+			Context("given `keyword` param is set", func() {
+				It("shows only `keyword` filtered records", func() {
+					keywordFilter := "expected_keyword"
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					// Exact match keyword
+					_ = FabricateKeyword(keywordFilter, faker.URL(), 0, user)
+					// Fuzzy match keyword
+					_ = FabricateKeyword(fmt.Sprintf("%v %v %v", faker.Word(), keywordFilter, faker.Word()), faker.URL(), 0, user)
+					// Non-match keyword
+					_ = FabricateKeyword("nonexpected__keyword", faker.URL(), 0, user)
+
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/api/v1/keywords?keyword=%v", keywordFilter), headers, nil, nil)
+
+					responseKeywords, err := jsonapi.UnmarshalManyPayload(response.Body, reflect.TypeOf(new(v1serializers.KeywordItemResponse)))
+					if err != nil {
+						Fail(fmt.Sprintf("Unmarshal many payload `KeywordItemResponse` list failed: %v", err.Error()))
+					}
+
+					Expect(len(responseKeywords)).To(Equal(2))
+				})
+			})
+		})
+
+		Context("given an INVALID access token", func() {
+			It("returns status 401", func() {
+				accessToken := "INVALID"
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+				response := MakeAuthenticatedRequest("GET", "/api/v1/keywords", headers, nil, nil)
+
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+
+			It("matches with INVALID schema", func() {
+				accessToken := "INVALID"
+				keyword := faker.Word()
+				form := url.Values{"keyword": {keyword}}
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+				body := strings.NewReader(form.Encode())
+
+				response := MakeAuthenticatedRequest("GET", "/api/v1/keywords", headers, body, nil)
+
+				Expect(response).To(MatchJSONSchema("keyword/list/invalid"))
+			})
+		})
 	})
 
 	Describe("POST /api/v1/keyword/search", func() {

--- a/controllers/api/v1/keyword_test.go
+++ b/controllers/api/v1/keyword_test.go
@@ -64,7 +64,7 @@ var _ = Describe("KeywordController", func() {
 			})
 
 			Context("given `p`(page) param is set", func() {
-				It("shows only records in page number 2", func() {
+				It("shows only records of page number 2", func() {
 					pageAt := 2
 					totalRecords := 12
 					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())

--- a/controllers/api/v1/token.go
+++ b/controllers/api/v1/token.go
@@ -49,16 +49,12 @@ func (c *TokenController) Create() {
 	err := oauth.ServerOauth.HandleTokenRequest(writer, c.Ctx.Request)
 	if err != nil {
 		c.RenderUnauthorizedError(err)
-
-		return
 	}
 
 	jsonResponse := writer.Body.Bytes()
 
 	if writer.Code != 200 {
 		c.handleResponseError(writer)
-
-		return
 	}
 
 	var tokenResponseObject v1serializers.TokenInformation
@@ -66,8 +62,6 @@ func (c *TokenController) Create() {
 	err = json.Unmarshal(jsonResponse, &tokenResponseObject)
 	if err != nil {
 		c.RenderGenericError(err)
-
-		return
 	}
 
 	c.RenderJSON(tokenResponseObject.Data(), http.StatusOK)

--- a/helpers/pagination_helper.go
+++ b/helpers/pagination_helper.go
@@ -1,0 +1,9 @@
+package helpers
+
+import (
+	"math"
+)
+
+func GetTotalPages(totalRows int, pageSize int) (totalPages int) {
+	return int(math.Ceil(float64(totalRows) / float64(pageSize)))
+}

--- a/helpers/pagination_helper.go
+++ b/helpers/pagination_helper.go
@@ -1,9 +1,0 @@
-package helpers
-
-import (
-	"math"
-)
-
-func GetTotalPages(totalRows int, pageSize int) (totalPages int) {
-	return int(math.Ceil(float64(totalRows) / float64(pageSize)))
-}

--- a/helpers/utility_map_helper.go
+++ b/helpers/utility_map_helper.go
@@ -1,7 +1,7 @@
 package helpers
 
-// GetMapKeyByNumber returns a firstly key from searching by value
-func GetMapKeyByNumber(mapList map[string]int, value int) string {
+// GetMapKeyByNumberValue returns the key of the first entry matched by its value
+func GetMapKeyByNumberValue(mapList map[string]int, value int) string {
 	for k, v := range mapList {
 		if v == value {
 			return k

--- a/helpers/utility_map_helper.go
+++ b/helpers/utility_map_helper.go
@@ -1,5 +1,6 @@
 package helpers
 
+// GetMapKeyByNumber returns a firstly key from searching by value
 func GetMapKeyByNumber(mapList map[string]int, value int) string {
 	for k, v := range mapList {
 		if v == value {

--- a/helpers/utility_map_helper.go
+++ b/helpers/utility_map_helper.go
@@ -1,0 +1,11 @@
+package helpers
+
+func GetMapKeyByNumber(mapList map[string]int, value int) string {
+	for k, v := range mapList {
+		if v == value {
+			return k
+		}
+	}
+
+	return ""
+}

--- a/helpers/utility_map_helper_test.go
+++ b/helpers/utility_map_helper_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 var _ = Describe("UtilityMapHelper", func() {
-	Describe("#GetMapKeyByNumber", func() {
+	Describe("#GetMapKeyByNumberValue", func() {
 		Context("given a valid map list with integer", func() {
-			It("returns the first key", func() {
+			It("returns the key of the first entry matched", func() {
 				mapList := map[string]int{"one": 1, "two": 2}
-				key := helpers.GetMapKeyByNumber(mapList, 1)
+				key := helpers.GetMapKeyByNumberValue(mapList, 1)
 
 				Expect(key).To(Equal("one"))
 				Expect(key).NotTo(Equal("two"))

--- a/helpers/utility_map_helper_test.go
+++ b/helpers/utility_map_helper_test.go
@@ -1,0 +1,22 @@
+package helpers_test
+
+import (
+	"go-crawler-challenge/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UtilityMapHelper", func() {
+	Describe("#GetMapKeyByNumber", func() {
+		Context("given a valid map list with integer", func() {
+			It("returns a firstly key", func() {
+				mapList := map[string]int{"one": 1, "two": 2, "another_one": 1}
+				key := helpers.GetMapKeyByNumber(mapList, 1)
+
+				Expect(key).To(Equal("one"))
+				Expect(key).NotTo(Equal("another_one"))
+			})
+		})
+	})
+})

--- a/helpers/utility_map_helper_test.go
+++ b/helpers/utility_map_helper_test.go
@@ -11,11 +11,11 @@ var _ = Describe("UtilityMapHelper", func() {
 	Describe("#GetMapKeyByNumber", func() {
 		Context("given a valid map list with integer", func() {
 			It("returns a firstly key", func() {
-				mapList := map[string]int{"one": 1, "two": 2, "another_one": 1}
+				mapList := map[string]int{"one": 1, "two": 2}
 				key := helpers.GetMapKeyByNumber(mapList, 1)
 
 				Expect(key).To(Equal("one"))
-				Expect(key).NotTo(Equal("another_one"))
+				Expect(key).NotTo(Equal("two"))
 			})
 		})
 	})

--- a/helpers/utility_map_helper_test.go
+++ b/helpers/utility_map_helper_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("UtilityMapHelper", func() {
 	Describe("#GetMapKeyByNumber", func() {
 		Context("given a valid map list with integer", func() {
-			It("returns a firstly key", func() {
+			It("returns the first key", func() {
 				mapList := map[string]int{"one": 1, "two": 2}
 				key := helpers.GetMapKeyByNumber(mapList, 1)
 

--- a/models/keyword.go
+++ b/models/keyword.go
@@ -81,6 +81,11 @@ func GetKeywordStatus(status string) int {
 	return keywordStatuses[status]
 }
 
+// GetKeywordStatuses returns keyword status list
+func GetKeywordStatuses() map[string]int {
+	return keywordStatuses
+}
+
 // UpdateKeyword updates Keyword by Id and returns error if the record to be updated doesn't exist
 func UpdateKeyword(keyword *Keyword) (err error) {
 	ormer := orm.NewOrm()

--- a/models/keyword_test.go
+++ b/models/keyword_test.go
@@ -412,6 +412,17 @@ var _ = Describe("Keyword", func() {
 		})
 	})
 
+	Describe("#GetKeywordStatuses", func() {
+		It("returns list of keyword status", func() {
+			keywordStatuses := models.GetKeywordStatuses()
+
+			Expect(keywordStatuses["failed"]).To(Equal(-1))
+			Expect(keywordStatuses["pending"]).To(Equal(0))
+			Expect(keywordStatuses["completed"]).To(Equal(1))
+			Expect(len(keywordStatuses)).To(Equal(3))
+		})
+	})
+
 	Describe("#UpdateKeyword", func() {
 		Context("given update keyword status from `pending` to `completed", func() {
 			user := FabricateUser(faker.Email(), faker.Password())

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -16,6 +16,15 @@ func init() {
 			Filters:          nil,
 			Params:           nil})
 
+	beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:KeywordController"] = append(beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:KeywordController"],
+		beego.ControllerComments{
+			Method:           "Index",
+			Router:           "/api/v1/keywords",
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
+
 	beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:TokenController"] = append(beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:TokenController"],
 		beego.ControllerComments{
 			Method:           "Create",

--- a/routers/router.go
+++ b/routers/router.go
@@ -33,7 +33,11 @@ func init() {
 	// API
 	// V1
 	namespaceV1 := web.NewNamespace("/api/v1",
+		// OAuth
 		web.NSRouter("/oauth/token", &apiv1controllers.TokenController{}, "post:Create"),
+
+		// Keyword
+		web.NSRouter("/keywords", &apiv1controllers.KeywordController{}, "get:Index"),
 		web.NSRouter("/keyword/search", &apiv1controllers.KeywordController{}, "post:TextSearch"),
 	)
 

--- a/serializers/v1/keyword_list.go
+++ b/serializers/v1/keyword_list.go
@@ -15,7 +15,7 @@ type KeywordList struct {
 	Paginator   *pagination.Paginator
 }
 
-type keywordItemResponse struct {
+type KeywordItemResponse struct {
 	Id               string `jsonapi:"primary,keywords"`
 	Keyword          string `jsonapi:"attr,keyword"`
 	Url              string `jsonapi:"attr,url"`
@@ -24,9 +24,9 @@ type keywordItemResponse struct {
 	CreatedAtTimeAgo string `jsonapi:"attr,created_at_time_ago"`
 }
 
-func (serializer *KeywordList) Data() (dataList []*keywordItemResponse) {
+func (serializer *KeywordList) Data() (dataList []*KeywordItemResponse) {
 	for _, keyword := range serializer.KeywordList {
-		dataList = append(dataList, &keywordItemResponse{
+		dataList = append(dataList, &KeywordItemResponse{
 			Id:               fmt.Sprint(keyword.Id),
 			Keyword:          keyword.Keyword,
 			Url:              keyword.Url,

--- a/serializers/v1/keyword_list.go
+++ b/serializers/v1/keyword_list.go
@@ -1,0 +1,39 @@
+package v1serializers
+
+import (
+	"fmt"
+
+	"go-crawler-challenge/helpers"
+	"go-crawler-challenge/models"
+)
+
+type KeywordList struct {
+	KeywordList []*models.Keyword
+	TotalRows   int
+	PageSize    int
+}
+
+type keywordItemResponse struct {
+	Id               string `jsonapi:"primary,keywords"`
+	Keyword          string `jsonapi:"attr,keyword"`
+	Url              string `jsonapi:"attr,url"`
+	Status           int    `jsonapi:"attr,status"`
+	StatusDetail     string `jsonapi:"attr,status_detail"`
+	CreatedAtTimeAgo string `jsonapi:"attr,created_at_time_ago"`
+	TotalPages       int    `jsonapi:"meta,total_pages"`
+}
+
+func (serializer *KeywordList) Data() (dataList []*keywordItemResponse) {
+	for _, keyword := range serializer.KeywordList {
+		dataList = append(dataList, &keywordItemResponse{
+			Id:               fmt.Sprint(keyword.Id),
+			Keyword:          keyword.Keyword,
+			Url:              keyword.Url,
+			Status:           keyword.Status,
+			StatusDetail:     helpers.GetMapKeyByNumber(models.GetKeywordStatuses(), keyword.Status),
+			CreatedAtTimeAgo: helpers.ToTimeAgo(keyword.CreatedAt),
+		})
+	}
+
+	return dataList
+}

--- a/serializers/v1/keyword_list.go
+++ b/serializers/v1/keyword_list.go
@@ -31,7 +31,7 @@ func (serializer *KeywordList) Data() (dataList []*KeywordItemResponse) {
 			Keyword:          keyword.Keyword,
 			Url:              keyword.Url,
 			Status:           keyword.Status,
-			StatusDetail:     helpers.GetMapKeyByNumber(models.GetKeywordStatuses(), keyword.Status),
+			StatusDetail:     helpers.GetMapKeyByNumberValue(models.GetKeywordStatuses(), keyword.Status),
 			CreatedAtTimeAgo: helpers.ToTimeAgo(keyword.CreatedAt),
 		})
 	}

--- a/serializers/v1/keyword_list.go
+++ b/serializers/v1/keyword_list.go
@@ -5,12 +5,14 @@ import (
 
 	"go-crawler-challenge/helpers"
 	"go-crawler-challenge/models"
+
+	"github.com/beego/beego/v2/adapter/utils/pagination"
+	"github.com/google/jsonapi"
 )
 
 type KeywordList struct {
 	KeywordList []*models.Keyword
-	TotalRows   int
-	PageSize    int
+	Paginator   *pagination.Paginator
 }
 
 type keywordItemResponse struct {
@@ -20,7 +22,6 @@ type keywordItemResponse struct {
 	Status           int    `jsonapi:"attr,status"`
 	StatusDetail     string `jsonapi:"attr,status_detail"`
 	CreatedAtTimeAgo string `jsonapi:"attr,created_at_time_ago"`
-	TotalPages       int    `jsonapi:"meta,total_pages"`
 }
 
 func (serializer *KeywordList) Data() (dataList []*keywordItemResponse) {
@@ -36,4 +37,26 @@ func (serializer *KeywordList) Data() (dataList []*keywordItemResponse) {
 	}
 
 	return dataList
+}
+
+func (serializer *KeywordList) Meta() (meta *jsonapi.Meta) {
+	meta = &jsonapi.Meta{
+		"total_pages": serializer.Paginator.PageNums(),
+	}
+
+	return meta
+}
+
+func (serializer *KeywordList) Links() (links *jsonapi.Links) {
+	currentPageAt := serializer.Paginator.Page()
+
+	links = &jsonapi.Links{
+		"self":  serializer.Paginator.PageLink(currentPageAt),
+		"first": serializer.Paginator.PageLinkFirst(),
+		"prev":  serializer.Paginator.PageLinkPrev(),
+		"next":  serializer.Paginator.PageLinkNext(),
+		"last":  serializer.Paginator.PageLinkLast(),
+	}
+
+	return links
 }

--- a/serializers/v1/keyword_list_test.go
+++ b/serializers/v1/keyword_list_test.go
@@ -20,7 +20,7 @@ var _ = Describe("V1/KeywordList", func() {
 	})
 
 	Describe("#Data", func() {
-		Context("given a valid data", func() {
+		Context("given valid data", func() {
 			It("returns serialize data", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				firstKeyword := FabricateKeyword(faker.Word(), faker.URL(), 0, user)

--- a/serializers/v1/keyword_list_test.go
+++ b/serializers/v1/keyword_list_test.go
@@ -1,0 +1,43 @@
+package v1serializers_test
+
+import (
+	"fmt"
+
+	"go-crawler-challenge/models"
+	v1serializers "go-crawler-challenge/serializers/v1"
+	. "go-crawler-challenge/tests/fixtures"
+
+	"github.com/bxcodec/faker/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("V1/KeywordList", func() {
+	Describe("#Data", func() {
+		Context("given a valid data", func() {
+			It("returns serialize data", func() {
+				user := FabricateUser(faker.Email(), faker.Password())
+				firstKeyword := FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+				secondKeyword := FabricateKeyword(faker.Word(), faker.URL(), 0, user)
+
+				anotherUser := FabricateUser(faker.Email(), faker.Password())
+				_ = FabricateKeyword(faker.Word(), faker.URL(), 0, anotherUser)
+
+				keywords, err := models.GetAllKeyword(map[string]interface{}{"user_id": user.Id}, []string{"created_at desc"}, 0, 10)
+				if err != nil {
+					Fail(fmt.Sprintf("Get all keyword failed: %v", err.Error()))
+				}
+
+				serializer := v1serializers.KeywordList{
+					KeywordList: keywords,
+				}
+
+				data := serializer.Data()
+
+				Expect(len(data)).To(Equal(2))
+				Expect(data[0].Id).To(Equal(fmt.Sprint(secondKeyword.Id)))
+				Expect(data[1].Id).To(Equal(fmt.Sprint(firstKeyword.Id)))
+			})
+		})
+	})
+})

--- a/serializers/v1/keyword_list_test.go
+++ b/serializers/v1/keyword_list_test.go
@@ -5,6 +5,7 @@ import (
 
 	"go-crawler-challenge/models"
 	v1serializers "go-crawler-challenge/serializers/v1"
+	. "go-crawler-challenge/tests"
 	. "go-crawler-challenge/tests/fixtures"
 
 	"github.com/bxcodec/faker/v3"
@@ -13,6 +14,11 @@ import (
 )
 
 var _ = Describe("V1/KeywordList", func() {
+	AfterEach(func() {
+		TruncateTable("keyword")
+		TruncateTable("user")
+	})
+
 	Describe("#Data", func() {
 		Context("given a valid data", func() {
 			It("returns serialize data", func() {

--- a/tests/api/schemas/keyword/list/invalid.json
+++ b/tests/api/schemas/keyword/list/invalid.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "errors": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "detail": {
+              "type": "string"
+            },
+            "code": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "title",
+            "detail",
+            "code"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/api/schemas/keyword/list/valid.json
+++ b/tests/api/schemas/keyword/list/valid.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "attributes": {
+              "type": "object",
+              "properties": {
+                "created_at_time_ago": {
+                  "type": "string"
+                },
+                "keyword": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "integer"
+                },
+                "status_detail": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "created_at_time_ago",
+                "keyword",
+                "status",
+                "status_detail",
+                "url"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "id",
+            "attributes"
+          ]
+        }
+      ]
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string"
+        },
+        "last": {
+          "type": "string"
+        },
+        "next": {
+          "type": "string"
+        },
+        "prev": {
+          "type": "string"
+        },
+        "self": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "first",
+        "last",
+        "next",
+        "prev",
+        "self"
+      ]
+    },
+    "meta": {
+      "type": "object",
+      "properties": {
+        "total_pages": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "total_pages"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Resolve https://github.com/Lahphim/go-crawler-challenge/issues/22

## What happened 👀

The user can make a request to the endpoint `[GET] /api/v1/keywords` to query all the stored data belonging to the user.
And also filter with `keyword` and `page` ✌️

## Insight 📝

- [x] Provide an endpoint to query all stored data
- [x] Return all stored data
- [x] Paginating those data 10 records/page

Sample request:

```curl
curl --location --request GET 'http://localhost:8080/api/v1/keywords?keyword=nd&p=1' \
--header 'Authorization: Bearer NWRHMTEXZTMTZMY0OS0ZZDKYLTHLMZMTMZIWNMNHNDDLYTC4'
```

Extra:

Providing valid JSON-LD format based on this schema here https://jsonapi.org/examples/#pagination

## Proof Of Work 📹

[GET] /api/v1/keywords?[keyword=XXXX]&[p=XXXX]
Query all stored data
| Valid Request | Invalid Request |
|---------------|----------------|
| <img width="600" alt="Screen Shot 2564-04-02 at 23 35 52" src="https://user-images.githubusercontent.com/749672/113435069-4dc1d880-940c-11eb-8928-dd982c7f4377.png"> | <img width="600" alt="Screen Shot 2564-04-02 at 23 36 22" src="https://user-images.githubusercontent.com/749672/113435098-5a463100-940c-11eb-8793-a833216f7f83.png"> |
