### PR TITLE
Bump golang from 1.15.x to 1.16.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
 
       - name: Lint
         uses: golangci/golangci-lint-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN npm install && npm run build
 
 
-FROM golang:1.15-alpine AS migration
+FROM golang:1.16-alpine AS migration
 
 ARG DATABASE_URL
 
@@ -30,7 +30,7 @@ RUN go get github.com/beego/bee/v2
 RUN bee migrate -driver=postgres -conn=$DATABASE_URL
 
 
-FROM golang:1.15-alpine AS app
+FROM golang:1.16-alpine AS app
 
 # Set necessary environment variables needed for our image
 ENV GO111MODULE=on \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The requirement of this project is about extracting large amounts of data from t
 - [Production](https://go-challenge.herokuapp.com/)
 
 ## Prerequisite
-* [Go - 1.15](https://golang.org/doc/go1.15)
+* [Go - 1.16](https://golang.org/doc/go1.16)
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go-crawler-challenge
 
-go 1.15
+go 1.16
 
 require (
 	github.com/PuerkitoBio/goquery v1.6.1


### PR DESCRIPTION
Resolve https://github.com/Lahphim/go-crawler-challenge/issues/74

## What happened 👀

Bumps [golang](https://golang.org/dl/) from 1.15.x to 1.16.x
Go 1.16 Release Notes: https://golang.org/doc/go1.16

## Proof Of Work 📹

N/A
