### PR TITLE
[API] As a user, I can view past report

### DIFF
--- a/controllers/api/base.go
+++ b/controllers/api/base.go
@@ -105,6 +105,12 @@ func (c *BaseController) RenderGenericError(err error) {
 	c.RenderError(http.StatusText(statusCode), err.Error(), statusCode, "generic_error")
 }
 
+func (c *BaseController) RenderNotFoundError(err error) {
+	statusCode := http.StatusNotFound
+
+	c.RenderError(http.StatusText(statusCode), err.Error(), statusCode, "not_found_error")
+}
+
 func (c *BaseController) RenderUnauthorizedError(err error) {
 	statusCode := http.StatusUnauthorized
 

--- a/controllers/api/constants.go
+++ b/controllers/api/constants.go
@@ -15,6 +15,8 @@ var (
 	ErrorInvalidUser           = errors.New("invalid user")
 	ErrorInvalidPayloaderType  = errors.New("invalid payload type")
 	ErrorMissingAccessToken    = errors.New("missing access token")
+	ErrorNotFoundReport        = errors.New("report not found")
 	ErrorNotFoundUser          = errors.New("user not found")
+	ErrorGenerateReportFailed  = errors.New("there was a problem generating a report")
 	ErrorRetrieveKeywordFailed = errors.New("there was a problem retrieving all keywords")
 )

--- a/controllers/api/v1/report.go
+++ b/controllers/api/v1/report.go
@@ -47,7 +47,7 @@ func (c *ReportController) Show() {
 
 	keyword, err := models.GetKeywordBy(query, []string{})
 	if err != nil {
-		c.RenderGenericError(ErrorNotFoundReport)
+		c.RenderNotFoundError(ErrorGenerateReportFailed)
 	}
 
 	reportGeneratorService := service.ReportGenerator{Keyword: keyword}

--- a/controllers/api/v1/report.go
+++ b/controllers/api/v1/report.go
@@ -48,16 +48,12 @@ func (c *ReportController) Show() {
 	keyword, err := models.GetKeywordBy(query, []string{})
 	if err != nil {
 		c.RenderGenericError(ErrorNotFoundReport)
-
-		return
 	}
 
 	reportGeneratorService := service.ReportGenerator{Keyword: keyword}
 	reportResult, err := reportGeneratorService.Generate()
 	if err != nil {
 		c.RenderGenericError(ErrorGenerateReportFailed)
-
-		return
 	}
 
 	serializer := v1serializers.ReportDetail{

--- a/controllers/api/v1/report.go
+++ b/controllers/api/v1/report.go
@@ -34,6 +34,7 @@ func (c *ReportController) actionPolicyMapping() {
 // @Description show the search result of the given keyword stored in the database
 // @Success 202 {object} v1serializers.ReportDetail
 // @Param :keyword_id path string true
+// @Failure 404 Report Not Error
 // @Failure 500 Internal Server Error
 // @Accept json
 // @router /api/v1/report/:keyword_id [post]
@@ -47,7 +48,7 @@ func (c *ReportController) Show() {
 
 	keyword, err := models.GetKeywordBy(query, []string{})
 	if err != nil {
-		c.RenderNotFoundError(ErrorGenerateReportFailed)
+		c.RenderNotFoundError(ErrorNotFoundReport)
 	}
 
 	reportGeneratorService := service.ReportGenerator{Keyword: keyword}

--- a/controllers/api/v1/report_test.go
+++ b/controllers/api/v1/report_test.go
@@ -27,7 +27,7 @@ var _ = Describe("ReportController", func() {
 
 	Describe("GET /api/v1/report/:keyword_id", func() {
 		Context("given a valid access token", func() {
-			Context("given a valid report", func() {
+			Context("given a valid keyword ID", func() {
 				It("returns status 200", func() {
 					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
 					user := FabricateUser(faker.Email(), faker.Password())
@@ -61,8 +61,8 @@ var _ = Describe("ReportController", func() {
 				})
 			})
 
-			Context("given an INVALID report", func() {
-				It("returns status 500", func() {
+			Context("given an INVALID keyword ID", func() {
+				It("returns status 404", func() {
 					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
 					user := FabricateUser(faker.Email(), faker.Password())
 					keyword := FabricateKeyword(faker.Word(), faker.URL(), models.GetKeywordStatus("pending"), user)
@@ -72,7 +72,7 @@ var _ = Describe("ReportController", func() {
 
 					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/api/v1/report/%v", keyword.Id), headers, nil, nil)
 
-					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 				})
 
 				It("matches with INVALID schema", func() {

--- a/controllers/api/v1/report_test.go
+++ b/controllers/api/v1/report_test.go
@@ -1,0 +1,113 @@
+package apiv1controllers_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"go-crawler-challenge/models"
+	. "go-crawler-challenge/tests"
+	. "go-crawler-challenge/tests/custom_matchers"
+	. "go-crawler-challenge/tests/fixtures"
+
+	"github.com/bxcodec/faker/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ReportController", func() {
+	AfterEach(func() {
+		TruncateTable("oauth2_tokens")
+		TruncateTable("oauth2_clients")
+		TruncateTable("link")
+		TruncateTable("page")
+		TruncateTable("position")
+		TruncateTable("keyword")
+		TruncateTable("user")
+	})
+
+	Describe("GET /api/v1/report/:keyword_id", func() {
+		Context("given a valid access token", func() {
+			Context("given a valid report", func() {
+				It("returns status 200", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					keyword := FabricateKeyword(faker.Word(), faker.URL(), models.GetKeywordStatus("completed"), user)
+					position := FabricatePosition(faker.Word(), faker.Word(), "normal")
+					_ = FabricatePage(faker.Paragraph(), keyword)
+					_ = FabricateLink(faker.URL(), keyword, position)
+
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/api/v1/report/%v", keyword.Id), headers, nil, nil)
+
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+
+				It("matches with valid schema", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					keyword := FabricateKeyword(faker.Word(), faker.URL(), models.GetKeywordStatus("completed"), user)
+					position := FabricatePosition(faker.Word(), faker.Word(), "normal")
+					_ = FabricatePage(faker.Paragraph(), keyword)
+					_ = FabricateLink(faker.URL(), keyword, position)
+
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/api/v1/report/%v", keyword.Id), headers, nil, nil)
+
+					Expect(response).To(MatchJSONSchema("report/show/valid"))
+				})
+			})
+
+			Context("given an INVALID report", func() {
+				It("returns status 500", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					keyword := FabricateKeyword(faker.Word(), faker.URL(), models.GetKeywordStatus("pending"), user)
+
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/api/v1/report/%v", keyword.Id), headers, nil, nil)
+
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+
+				It("matches with INVALID schema", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					keyword := FabricateKeyword(faker.Word(), faker.URL(), models.GetKeywordStatus("pending"), user)
+
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+					response := MakeAuthenticatedRequest("GET", fmt.Sprintf("/api/v1/report/%v", keyword.Id), headers, nil, nil)
+
+					Expect(response).To(MatchJSONSchema("report/show/invalid"))
+				})
+			})
+		})
+
+		Context("given an INVALID access token", func() {
+			It("returns status 401", func() {
+				accessToken := "INVALID"
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+				response := MakeAuthenticatedRequest("GET", "/api/v1/report/0", headers, nil, nil)
+
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+
+			It("matches with INVALID schema", func() {
+				accessToken := "INVALID"
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+				response := MakeAuthenticatedRequest("GET", "/api/v1/report/0", headers, nil, nil)
+
+				Expect(response).To(MatchJSONSchema("report/show/invalid"))
+			})
+		})
+	})
+})

--- a/controllers/report_test.go
+++ b/controllers/report_test.go
@@ -26,7 +26,7 @@ var _ = Describe("ReportController", func() {
 		TruncateTable("user")
 	})
 
-	Describe("GET /report/:key_id", func() {
+	Describe("GET /report/:keyword_id", func() {
 		Context("when the user has already signed in", func() {
 			Context("given a valid report", func() {
 				It("renders with status 200", func() {

--- a/models/report.go
+++ b/models/report.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"time"
+)
+
+// Report : Report model
+type Report struct {
+	Id      int64
+	Keyword string
+	Url     string
+	RawHtml string
+
+	LinkList map[string][]string
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	TotalAdsTop int
+	TotalAds    int
+	TotalNonAds int
+	TotalLink   int
+}

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -25,6 +25,15 @@ func init() {
 			Filters:          nil,
 			Params:           nil})
 
+	beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:ReportController"] = append(beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:ReportController"],
+		beego.ControllerComments{
+			Method:           "Show",
+			Router:           "/api/v1/report/:keyword_id",
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
+
 	beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:TokenController"] = append(beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:TokenController"],
 		beego.ControllerComments{
 			Method:           "Create",

--- a/routers/router.go
+++ b/routers/router.go
@@ -39,6 +39,9 @@ func init() {
 		// Keyword
 		web.NSRouter("/keywords", &apiv1controllers.KeywordController{}, "get:Index"),
 		web.NSRouter("/keyword/search", &apiv1controllers.KeywordController{}, "post:TextSearch"),
+
+		// Report
+		web.NSRouter("/report/:keyword_id", &apiv1controllers.ReportController{}, "get:Show"),
 	)
 
 	web.AddNamespace(namespaceV1)

--- a/serializers/v1/report_detail.go
+++ b/serializers/v1/report_detail.go
@@ -1,0 +1,52 @@
+package v1serializers
+
+import (
+	"fmt"
+	"time"
+
+	"go-crawler-challenge/models"
+)
+
+type ReportDetail struct {
+	Report *models.Report
+}
+
+type reportDetailResponse struct {
+	Id      string `jsonapi:"primary,reports"`
+	Keyword string `jsonapi:"attr,keyword"`
+	Url     string `jsonapi:"attr,url"`
+	RawHtml string `jsonapi:"attr,raw_html"`
+
+	LinkList map[string][]string `jsonapi:"attr,link_list"`
+
+	CreatedAt time.Time `jsonapi:"attr,created_at"`
+	UpdatedAt time.Time `jsonapi:"attr,updated_at"`
+
+	TotalAdsTop int `jsonapi:"attr,total_ads_top"`
+	TotalAds    int `jsonapi:"attr,total_ads"`
+	TotalNonAds int `jsonapi:"attr,total_non_ads"`
+	TotalLink   int `jsonapi:"attr,total_link"`
+}
+
+func (serializer *ReportDetail) Data() (reportDetail *reportDetailResponse) {
+	report := serializer.Report
+
+	reportDetail = &reportDetailResponse{
+		Id:      fmt.Sprint(report.Id),
+		Keyword: report.Keyword,
+		Url:     report.Url,
+		RawHtml: report.RawHtml,
+
+		LinkList: report.LinkList,
+
+		CreatedAt: report.CreatedAt.Local(),
+		UpdatedAt: report.UpdatedAt.Local(),
+
+		TotalAdsTop: report.TotalAdsTop,
+		TotalAds:    report.TotalAds,
+		TotalNonAds: report.TotalNonAds,
+		TotalLink:   report.TotalLink,
+	}
+
+	return reportDetail
+}

--- a/serializers/v1/report_detail.go
+++ b/serializers/v1/report_detail.go
@@ -12,7 +12,7 @@ type ReportDetail struct {
 }
 
 type reportDetailResponse struct {
-	Id      string `jsonapi:"primary,reports"`
+	Id      string `jsonapi:"primary,report"`
 	Keyword string `jsonapi:"attr,keyword"`
 	Url     string `jsonapi:"attr,url"`
 	RawHtml string `jsonapi:"attr,raw_html"`

--- a/serializers/v1/report_detail_test.go
+++ b/serializers/v1/report_detail_test.go
@@ -1,0 +1,60 @@
+package v1serializers_test
+
+import (
+	"time"
+
+	"go-crawler-challenge/models"
+	v1serializers "go-crawler-challenge/serializers/v1"
+
+	"github.com/bxcodec/faker/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("V1/ReportDetail", func() {
+	Describe("#Data", func() {
+		Context("given valid data", func() {
+			It("returns serialize data", func() {
+				adsTopLink := []string{faker.URL(), faker.URL(), faker.URL(), faker.URL()}
+				adsOtherLink := []string{faker.URL()}
+				normalLink := []string{faker.URL(), faker.URL(), faker.URL()}
+
+				report := &models.Report{
+					Id:      0,
+					Keyword: faker.Word(),
+					Url:     faker.URL(),
+					RawHtml: faker.Sentence(),
+
+					LinkList: map[string][]string{"normal": normalLink, "other": adsOtherLink, "top": adsTopLink},
+
+					CreatedAt: time.Now().Local(),
+					UpdatedAt: time.Now().Local(),
+
+					TotalAdsTop: len(adsTopLink),
+					TotalAds:    len(adsTopLink) + len(adsOtherLink),
+					TotalNonAds: len(normalLink),
+					TotalLink:   len(adsTopLink) + len(adsOtherLink) + len(normalLink),
+				}
+
+				serializer := v1serializers.ReportDetail{
+					Report: report,
+				}
+
+				var data = serializer.Data()
+
+				Expect(data).NotTo(BeNil())
+				Expect(data.Id).To(Equal("0"))
+				Expect(len(data.Keyword)).To(BeNumerically(">", 0))
+				Expect(len(data.Url)).To(BeNumerically(">", 0))
+				Expect(len(data.RawHtml)).To(BeNumerically(">", 0))
+				Expect(len(data.LinkList["normal"])).To(BeNumerically(">=", 0))
+				Expect(len(data.LinkList["other"])).To(BeNumerically(">=", 0))
+				Expect(len(data.LinkList["top"])).To(BeNumerically(">=", 0))
+				Expect(data.TotalAdsTop).To(Equal(len(adsTopLink)))
+				Expect(data.TotalAds).To(Equal(len(adsTopLink) + len(adsOtherLink)))
+				Expect(data.TotalNonAds).To(Equal(len(normalLink)))
+				Expect(data.TotalLink).To(Equal(len(adsTopLink) + len(adsOtherLink) + len(normalLink)))
+			})
+		})
+	})
+})

--- a/services/keyword/report_generator.go
+++ b/services/keyword/report_generator.go
@@ -1,8 +1,6 @@
 package keyword
 
 import (
-	"time"
-
 	"go-crawler-challenge/models"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -10,22 +8,6 @@ import (
 
 type ReportGenerator struct {
 	Keyword *models.Keyword
-}
-
-type Report struct {
-	Keyword string
-	Url     string
-	RawHtml string
-
-	LinkList map[string][]string
-
-	CreatedAt time.Time
-	UpdatedAt time.Time
-
-	TotalAdsTop int
-	TotalAds    int
-	TotalNonAds int
-	TotalLink   int
 }
 
 // Generate handles processing and generating the report based on a given keyword.
@@ -64,7 +46,8 @@ func (service *ReportGenerator) Generate() (reportInterface interface{}, err err
 	totalAdsOther := len(linkList["other"])
 	totalNonAds := len(linkList["normal"])
 
-	reportResult := Report{
+	reportResult := &models.Report{
+		Id:      keywordRecord.Id,
 		Keyword: keywordRecord.Keyword,
 		Url:     keywordRecord.Url,
 		RawHtml: keywordRecord.Page.RawHtml,

--- a/services/keyword/report_generator_test.go
+++ b/services/keyword/report_generator_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Keyword/ReportGenerator", func() {
 				if err != nil {
 					Fail(fmt.Sprintf("Generate report failed: %v", err.Error()))
 				} else {
-					reportInterface := reportResult.(models.Report)
+					reportInterface := reportResult.(*models.Report)
 
 					Expect(reportInterface.Keyword).To(Equal(keyword.Keyword))
 					Expect(reportInterface.Url).To(Equal(keyword.Url))

--- a/services/keyword/report_generator_test.go
+++ b/services/keyword/report_generator_test.go
@@ -3,6 +3,7 @@ package keyword_test
 import (
 	"fmt"
 
+	"go-crawler-challenge/models"
 	service "go-crawler-challenge/services/keyword"
 	. "go-crawler-challenge/tests"
 	. "go-crawler-challenge/tests/fixtures"
@@ -39,7 +40,7 @@ var _ = Describe("Keyword/ReportGenerator", func() {
 				if err != nil {
 					Fail(fmt.Sprintf("Generate report failed: %v", err.Error()))
 				} else {
-					reportInterface := reportResult.(service.Report)
+					reportInterface := reportResult.(models.Report)
 
 					Expect(reportInterface.Keyword).To(Equal(keyword.Keyword))
 					Expect(reportInterface.Url).To(Equal(keyword.Url))

--- a/tests/api/schemas/report/show/invalid.json
+++ b/tests/api/schemas/report/show/invalid.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "errors": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "detail": {
+              "type": "string"
+            },
+            "code": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "title",
+            "detail",
+            "code"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/api/schemas/report/show/valid.json
+++ b/tests/api/schemas/report/show/valid.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "raw_html": {
+              "type": "string"
+            },
+            "link_list": {
+              "type": "object",
+              "properties": {
+                "normal": {
+                  "type": "array"
+                },
+                "other": {
+                  "type": "array"
+                },
+                "top": {
+                  "type": "array"
+                }
+              }
+            },
+            "created_at": {
+              "type": "integer"
+            },
+            "updated_at": {
+              "type": "integer"
+            },
+            "total_ads_top": {
+              "type": "integer"
+            },
+            "total_ads": {
+              "type": "integer"
+            },
+            "total_non_ads": {
+              "type": "integer"
+            },
+            "total_link": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "keyword",
+            "url",
+            "raw_html",
+            "link_list",
+            "created_at",
+            "updated_at",
+            "total_ads_top",
+            "total_ads",
+            "total_non_ads",
+            "total_link"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/request_helper.go
+++ b/tests/request_helper.go
@@ -28,11 +28,16 @@ func GenerateRequestBody(data map[string]string) (body io.Reader) {
 
 // GetCurrentPath gets current path from HTTP response and return the current url path
 func GetCurrentPath(response *http.Response) string {
-	url, err := response.Location()
+	locationUrl, err := response.Location()
 	if err != nil {
 		ginkgo.Fail("Get current path failed: " + err.Error())
 	}
-	return url.Path
+
+	if locationUrl == nil {
+		return ""
+	}
+
+	return locationUrl.Path
 }
 
 // MakeRequest makes a HTTP request and returns response


### PR DESCRIPTION
Resolve https://github.com/Lahphim/go-crawler-challenge/issues/24

## What happened 👀

The user can make a request to get the report detail from this endpoint `/api/v1/report/:keyword_id`.
In case that the report haven't completed with the service scrapping google page, it will not report the report detail 😛

## Insight 📝

- [x] Provide an endpoint to view report
- [x] Return report data

Sample request:
```curl
curl --location --request GET 'http://localhost:8080/api/v1/report/1' \
--header 'Authorization: Bearer Y2MZOTG2NWITZGZIMY0ZN2Q3LTHKNJGTZJIZODZLNZDIMZM4'
```

## Proof Of Work 📹

[GET] /api/v1/report/:keyword_id
Show report detail

| Valid Request | Invalid Request |
|---------------|----------------|
| <img width="600" alt="Screen Shot 2564-04-05 at 17 21 05" src="https://user-images.githubusercontent.com/749672/113564402-88598a00-9633-11eb-869f-052e2609a87b.png"> | <img width="600" alt="Screen Shot 2564-04-05 at 17 21 20" src="https://user-images.githubusercontent.com/749672/113564416-8d1e3e00-9633-11eb-86f9-4fc08327d496.png"> |



