### PR TITLE
[API] As a user, I can upload CSV file of keywords

### DIFF
--- a/controllers/api/base.go
+++ b/controllers/api/base.go
@@ -79,6 +79,10 @@ func (c *BaseController) RenderJSONList(data interface{}, meta *jsonapi.Meta, li
 }
 
 func (c *BaseController) RenderJSON(data interface{}, status int) {
+	if data == nil {
+		c.renderJSON(nil, status)
+	}
+
 	response, err := jsonapi.Marshal(data)
 	if err != nil {
 		c.RenderGenericError(err)

--- a/controllers/api/base.go
+++ b/controllers/api/base.go
@@ -121,6 +121,12 @@ func (c *BaseController) RenderUnauthorizedError(err error) {
 	c.RenderError(http.StatusText(statusCode), err.Error(), statusCode, "unauthorized_error")
 }
 
+func (c *BaseController) RenderUnprocessableEntityError(err error) {
+	statusCode := http.StatusUnprocessableEntity
+
+	c.RenderError(http.StatusText(statusCode), err.Error(), statusCode, "unprocessable_entity_error")
+}
+
 func (c *BaseController) RenderError(title string, detail string, status int, code string) {
 	c.Ctx.ResponseWriter.WriteHeader(status)
 

--- a/controllers/api/constants.go
+++ b/controllers/api/constants.go
@@ -19,4 +19,5 @@ var (
 	ErrorNotFoundUser          = errors.New("user not found")
 	ErrorGenerateReportFailed  = errors.New("there was a problem generating a report")
 	ErrorRetrieveKeywordFailed = errors.New("there was a problem retrieving all keywords")
+	ErrorUploadFileFailed      = errors.New("the specified file could not be uploaded")
 )

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -111,7 +111,7 @@ func (c *KeywordController) TextSearch() {
 func (c *KeywordController) FileSearch() {
 	file, fileHeader, err := c.GetFile("file")
 	if err != nil {
-		c.RenderGenericError(ErrorUploadFileFailed)
+		c.RenderUnprocessableEntityError(ErrorUploadFileFailed)
 	}
 
 	fileForm := form.FileSearchForm{File: file, FileHeader: fileHeader, User: c.CurrentUser}

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -117,7 +117,7 @@ func (c *KeywordController) FileSearch() {
 	fileForm := form.FileSearchForm{File: file, FileHeader: fileHeader, User: c.CurrentUser}
 	err = fileForm.Save()
 	if err != nil {
-		c.RenderGenericError(err)
+		c.RenderUnprocessableEntityError(err)
 	}
 
 	c.RenderJSON(nil, http.StatusNoContent)

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -106,7 +106,7 @@ func (c *KeywordController) TextSearch() {
 // @Description create new scrapping result by CSV file
 // @Success 201
 // @Param file formData file true
-// @Failure 500 Internal Server Error
+// @Failure 422 Unprocessable Entity Error
 // @router /api/v1/keyword/upload [post]
 func (c *KeywordController) FileSearch() {
 	file, fileHeader, err := c.GetFile("file")

--- a/controllers/api/v1/keyword.go
+++ b/controllers/api/v1/keyword.go
@@ -26,12 +26,14 @@ func (c *KeywordController) NestPrepare() {
 func (c *KeywordController) URLMapping() {
 	c.Mapping("Index", c.Index)
 	c.Mapping("TextSearch", c.TextSearch)
+	c.Mapping("FileSearch", c.FileSearch)
 }
 
 // actionPolicyMapping maps keyword controller actions to policies
 func (c *KeywordController) actionPolicyMapping() {
 	c.MappingPolicy("Index", Policy{RequireAuthenticatedUser: true})
 	c.MappingPolicy("TextSearch", Policy{RequireAuthenticatedUser: true})
+	c.MappingPolicy("FileSearch", Policy{RequireAuthenticatedUser: true})
 }
 
 // Index handles keyword list
@@ -97,4 +99,26 @@ func (c *KeywordController) TextSearch() {
 	serializer := v1serializers.KeywordScraper{Message: "Scraping a keyword :)"}
 
 	c.RenderJSON(serializer.Data(), http.StatusCreated)
+}
+
+// FileSearch handles keyword for scrapping
+// @Title FileSearch
+// @Description create new scrapping result by CSV file
+// @Success 201
+// @Param file formData file true
+// @Failure 500 Internal Server Error
+// @router /api/v1/keyword/upload [post]
+func (c *KeywordController) FileSearch() {
+	file, fileHeader, err := c.GetFile("file")
+	if err != nil {
+		c.RenderGenericError(ErrorUploadFileFailed)
+	}
+
+	fileForm := form.FileSearchForm{File: file, FileHeader: fileHeader, User: c.CurrentUser}
+	err = fileForm.Save()
+	if err != nil {
+		c.RenderGenericError(err)
+	}
+
+	c.RenderJSON(nil, http.StatusNoContent)
 }

--- a/controllers/api/v1/keyword_test.go
+++ b/controllers/api/v1/keyword_test.go
@@ -317,7 +317,7 @@ var _ = Describe("KeywordController", func() {
 			})
 
 			Context("given an INVALID upload file", func() {
-				It("returns status 500", func() {
+				It("returns status 422", func() {
 					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
 					user := FabricateUser(faker.Email(), faker.Password())
 					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
@@ -326,7 +326,7 @@ var _ = Describe("KeywordController", func() {
 
 					response := MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, body, nil)
 
-					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
 				})
 
 				It("does NOT create any new keywords", func() {

--- a/controllers/api/v1/keyword_test.go
+++ b/controllers/api/v1/keyword_test.go
@@ -276,4 +276,114 @@ var _ = Describe("KeywordController", func() {
 			})
 		})
 	})
+
+	Describe("POST /api/v1/keyword/upload", func() {
+		Context("given a valid access token", func() {
+			Context("given a valid upload file", func() {
+				It("returns status 204", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers, body := CreateMultipartRequestInfo("tests/fixtures/files/valid.csv", "text/csv")
+					headers.Add("Authorization", fmt.Sprintf("Bearer %v", accessToken))
+
+					response := MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, body, nil)
+
+					Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+				})
+
+				It("creates keyword list", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers, body := CreateMultipartRequestInfo("tests/fixtures/files/valid.csv", "text/csv")
+					headers.Add("Authorization", fmt.Sprintf("Bearer %v", accessToken))
+					queryList := map[string]interface{}{"user_id": user.Id}
+
+					totalRowsBeforeRequest, err := models.CountAllKeyword(queryList)
+					if err != nil {
+						Fail(fmt.Sprintf("Count all keyword failed: %v", err.Error()))
+					}
+
+					_ = MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, body, nil)
+
+					totalRowsAfterRequest, err := models.CountAllKeyword(queryList)
+					if err != nil {
+						Fail(fmt.Sprintf("Count all keyword failed: %v", err.Error()))
+					}
+
+					Expect(totalRowsAfterRequest - totalRowsBeforeRequest).To(BeNumerically(">", 0))
+				})
+			})
+
+			Context("given an INVALID upload file", func() {
+				It("returns status 500", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers, body := CreateMultipartRequestInfo("tests/fixtures/files/text.txt", "text/plain")
+					headers.Add("Authorization", fmt.Sprintf("Bearer %v", accessToken))
+
+					response := MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, body, nil)
+
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+
+				It("does NOT create any new keywords", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers, body := CreateMultipartRequestInfo("tests/fixtures/files/text.txt", "text/plain")
+					headers.Add("Authorization", fmt.Sprintf("Bearer %v", accessToken))
+					queryList := map[string]interface{}{"user_id": user.Id}
+
+					totalRowsBeforeRequest, err := models.CountAllKeyword(queryList)
+					if err != nil {
+						Fail(fmt.Sprintf("Count all keyword failed: %v", err.Error()))
+					}
+
+					_ = MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, body, nil)
+
+					totalRowsAfterRequest, err := models.CountAllKeyword(queryList)
+					if err != nil {
+						Fail(fmt.Sprintf("Count all keyword failed: %v", err.Error()))
+					}
+
+					Expect(totalRowsAfterRequest - totalRowsBeforeRequest).To(BeNumerically("==", 0))
+				})
+
+				It("matches with INVALID schema", func() {
+					oauthClient := FabricateOauthClient(faker.UUIDHyphenated(), faker.Password())
+					user := FabricateUser(faker.Email(), faker.Password())
+					accessToken := FabricatorAccessToken(oauthClient.ID, user.Id)
+					headers, body := CreateMultipartRequestInfo("tests/fixtures/files/text.txt", "text/plain")
+					headers.Add("Authorization", fmt.Sprintf("Bearer %v", accessToken))
+
+					response := MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, body, nil)
+
+					Expect(response).To(MatchJSONSchema("keyword/upload/invalid"))
+				})
+			})
+		})
+
+		Context("given an INVALID access token", func() {
+			It("returns status 401", func() {
+				accessToken := "INVALID"
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+				response := MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, nil, nil)
+
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+
+			It("matches with INVALID schema", func() {
+				accessToken := "INVALID"
+				headers := http.Header{"Authorization": {fmt.Sprintf("Bearer %v", accessToken)}}
+
+				response := MakeAuthenticatedRequest("POST", "/api/v1/keyword/upload", headers, nil, nil)
+
+				Expect(response).To(MatchJSONSchema("keyword/upload/invalid"))
+			})
+		})
+	})
 })

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -18,6 +18,15 @@ func init() {
 
 	beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:KeywordController"] = append(beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:KeywordController"],
 		beego.ControllerComments{
+			Method:           "FileSearch",
+			Router:           "/api/v1/keyword/upload",
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
+
+	beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:KeywordController"] = append(beego.GlobalControllerRouter["go-crawler-challenge/controllers/api/v1:KeywordController"],
+		beego.ControllerComments{
 			Method:           "Index",
 			Router:           "/api/v1/keywords",
 			AllowHTTPMethods: []string{"get"},

--- a/routers/router.go
+++ b/routers/router.go
@@ -39,6 +39,7 @@ func init() {
 		// Keyword
 		web.NSRouter("/keywords", &apiv1controllers.KeywordController{}, "get:Index"),
 		web.NSRouter("/keyword/search", &apiv1controllers.KeywordController{}, "post:TextSearch"),
+		web.NSRouter("/keyword/upload", &apiv1controllers.KeywordController{}, "post:FileSearch"),
 
 		// Report
 		web.NSRouter("/report/:keyword_id", &apiv1controllers.ReportController{}, "get:Show"),

--- a/tests/api/schemas/keyword/upload/invalid.json
+++ b/tests/api/schemas/keyword/upload/invalid.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "errors": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "detail": {
+              "type": "string"
+            },
+            "code": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "title",
+            "detail",
+            "code"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Resolve https://github.com/Lahphim/go-crawler-challenge/issues/20

## What happened 👀

The user can make a request with this endpoint `/api/v1/keyword/upload` with a CSV file of the keyword list.
So the user can add those keys in the waiting list with just one shot 🎯

## Insight 📝

- [x] Provide an endpoint about upload CSV file of keywords
- [x] Return submit result

Sample request:

```curl
curl --location --request POST 'http://localhost:8080/api/v1/keyword/upload' \
--header 'Authorization: Bearer MME2MDKZZWUTOTY1OS0ZZTK0LTK4YWUTZJM4YTFMZMMYZWFL' \
--form 'file=@"/Users/somsak/Desktop/valid-file.csv"'
```

## Proof Of Work 📹

[POST] /api/v1/keyword/upload
Upload file of keyword list

| Valid Request | Invalid Request |
|---------------|----------------|
| <img width="600" alt="Screen Shot 2564-04-06 at 03 04 59" src="https://user-images.githubusercontent.com/749672/113620788-fd08e480-9684-11eb-856c-4d34515ed1b2.png"> | <img width="600" alt="Screen Shot 2564-04-06 at 03 05 19" src="https://user-images.githubusercontent.com/749672/113620798-01350200-9685-11eb-8569-1a8116692c74.png"> |

